### PR TITLE
Correct typo

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -41,7 +41,7 @@ const Index = () => {
     );
   }
 
-  return <Layout>You're not sigend in.</Layout>;
+  return <Layout>You're not signed in.</Layout>;
 };
 
 // export async function getStaticProps() {


### PR DESCRIPTION
It should be "signed" instead of "sigend" on the first page of the user
interface. Closes #76